### PR TITLE
Add scheduled workflow to keep Quartz updated

### DIFF
--- a/.github/workflows/quartz-update.yml
+++ b/.github/workflows/quartz-update.yml
@@ -1,0 +1,55 @@
+name: Keep Quartz Updated
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  quartz-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update Quartz
+        run: npx quartz update
+
+      - name: Check types and formatting
+        run: npm run check
+
+      - name: Run tests
+        run: npm test
+
+      - name: Ensure Quartz builds
+        run: npx quartz build --bundleInfo -d docs
+
+      - name: Create Pull Request with updates
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update Quartz"
+          title: "chore: update Quartz"
+          body: |
+            Automated updates via `npx quartz update`.
+          branch: chore/quartz-update
+          delete-branch: true


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow to run Quartz update and validation commands
- automatically open a pull request with the resulting changes
- configure the workflow to use Node.js 22

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d06f8d59688330ba2f2bd89f012ff5