### PR TITLE
fix: add missing showSubfolders and sort properties to FolderContentOptions

### DIFF
--- a/quartz/components/pages/FolderContent.tsx
+++ b/quartz/components/pages/FolderContent.tsx
@@ -20,11 +20,20 @@ interface FolderContentOptions {
    * Whether to display a list of pages in the folder
    */
   showPageListing: boolean
+  /**
+   * Whether to show pages in subfolders
+   */
+  showSubfolders: boolean
+  /**
+   * Custom sort function for pages
+   */
+  sort?: SortFn
 }
 
 const defaultOptions: FolderContentOptions = {
   showFolderCount: true,
   showPageListing: false,
+  showSubfolders: false,
 }
 
 export default ((opts?: Partial<FolderContentOptions>) => {


### PR DESCRIPTION
The FolderContentOptions interface was missing showSubfolders and sort
properties that were being used in the component, causing TypeScript
compilation errors in the GitHub Actions workflow.