### PR TITLE
fix: configure git identity for quartz update workflow

### DIFF
--- a/.github/workflows/quartz-update.yml
+++ b/.github/workflows/quartz-update.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Configure git for automated commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Update Quartz
         run: npx quartz update
 


### PR DESCRIPTION
The `npx quartz update` command uses `git pull --autostash` which
requires git user identity to be configured to create the autostash
commit. Added git config step before running the update.