### PR TITLE
fix: discard workflow file changes before creating PR

### DIFF
--- a/.github/workflows/quartz-update.yml
+++ b/.github/workflows/quartz-update.yml
@@ -55,6 +55,11 @@ jobs:
         continue-on-error: true
         run: npx quartz build --bundleInfo -d docs
 
+      - name: Discard workflow file changes
+        run: |
+          # Reset any changes to workflow files to avoid needing workflows permission
+          git checkout HEAD -- .github/workflows/ 2>/dev/null || true
+
       - name: Create Pull Request with updates
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
The quartz update workflow was failing because upstream Quartz changes
included workflow file modifications (e.g., build-preview.yaml), and
the GITHUB_TOKEN lacks workflows permission to push those changes.

This fix resets any workflow file changes before creating the PR,
avoiding the permission issue while still allowing other updates.